### PR TITLE
Adding nightly checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install nightly
       uses: dtolnay/rust-toolchain@nightly
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo +stable clippy -- -D warnings
     - name: Build
-      run: cargo build
+      run: cargo +stable build
     - name: Run tests on stable
-      run: cargo test
+      run: cargo +stable test
     - name: Run tests on nightly, but with std
       run: cargo +nightly test --features nightly
     - name: Run tests on nightly no_std

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,14 +11,22 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
+    - name: Install Rust toolchains
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - name: Install nightly
+      uses: dtolnay/rust-toolchain@nightly
     - name: Clippy
       run: cargo clippy -- -D warnings
     - name: Build
       run: cargo build
-    - name: Run tests
+    - name: Run tests on stable
       run: cargo test
+    - name: Run tests on nightly, but with std
+      run: cargo +nightly test --features nightly
+    - name: Run tests on nightly no_std
+      run: cargo +nightly test --no-default-features --features nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trig-const"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85.0"
 categories = ["mathematics", "no-std"]
@@ -16,6 +16,5 @@ license = "MIT"
 libm = { version = "0.2", optional = true }
 
 [features]
-default = ["std"]
 std = []
 nightly = ["dep:libm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ keywords = ["const", "trig", "no_std"]
 license = "MIT"
 
 [dependencies]
+libm = { version = "0.2", optional = true }
+
+[features]
+default = ["std"]
+std = []
+nightly = ["dep:libm"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ fn main() {
 }
 ```
 
+## Features
+
+- `nightly`: Running in [nightly](https://rust-lang.github.io/rustup/concepts/channels.html) exposes the function [`const_eval_select`](https://doc.rust-lang.org/std/intrinsics/fn.const_eval_select.html). This allows the compiler to call a different function if the function is to be evaluated at compile-time or run-time
+  - Any `const` function calls will use this library
+  - Any runtime function calls will forward to `libm`.
+- `std`: This feature can be used in conjunction with `nightly`. This will forward runtime function calls to `std` instead of `libm`, to take advantage of hardware intrinsics (SIMD/FPU)
+
 ## Precision
 
 Precision will be different platform to platform. There is a precision comparison within examples, under `examples/std_cmp.rs` (to run: `cargo run --release --example std_cmp`).

--- a/src/acos.rs
+++ b/src/acos.rs
@@ -57,6 +57,10 @@ const QS4: f64 = 7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 /// assert_eq!(ACOS_1, 0.0);
 /// ```
 pub const fn acos(x: f64) -> f64 {
+    nightly_exp!(acos, acos_inner, x)
+}
+
+const fn acos_inner(x: f64) -> f64 {
     let x1p_120f = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ -120
     let z: f64;
     let w: f64;

--- a/src/acosh.rs
+++ b/src/acosh.rs
@@ -16,6 +16,10 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 /// assert_eq!(ACOSH_1, 0.0);
 /// ```
 pub const fn acosh(x: f64) -> f64 {
+    nightly_exp!(acosh, acosh_inner, x)
+}
+
+const fn acosh_inner(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
 

--- a/src/asin.rs
+++ b/src/asin.rs
@@ -68,7 +68,11 @@ const fn comp_r(z: f64) -> f64 {
 /// const ASIN_PI: f64 = asin(0.0);
 /// assert_eq!(ASIN_PI, 0.0);
 /// ```
-pub const fn asin(mut x: f64) -> f64 {
+pub const fn asin(x: f64) -> f64 {
+    nightly_exp!(asin, asin_inner, x)
+}
+
+const fn asin_inner(mut x: f64) -> f64 {
     let hx: u32 = get_high_word(x);
     let ix: u32 = hx & 0x7fffffff;
     /* |x| >= 1 or nan */

--- a/src/asinh.rs
+++ b/src/asinh.rs
@@ -12,7 +12,11 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 /// const ASINH_1: f64 = asinh(0.0);
 /// assert_eq!(ASINH_1, 0.0);
 /// ```
-pub const fn asinh(mut x: f64) -> f64 {
+pub const fn asinh(x: f64) -> f64 {
+    nightly_exp!(asinh, asinh_inner, x)
+}
+
+const fn asinh_inner(mut x: f64) -> f64 {
     let mut u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
     let sign = (u >> 63) != 0;

--- a/src/atan.rs
+++ b/src/atan.rs
@@ -68,6 +68,10 @@ const AT: [f64; 11] = [
 /// assert_eq!(ATAN_1, PI / 4.0);
 /// ```
 pub const fn atan(x: f64) -> f64 {
+    nightly_exp!(atan, atan_inner, x)
+}
+
+const fn atan_inner(x: f64) -> f64 {
     let mut x = x;
     let mut ix = (x.to_bits() >> 32) as u32;
     let sign = ix >> 31;

--- a/src/atan2.rs
+++ b/src/atan2.rs
@@ -49,6 +49,10 @@ use crate::{atan, fabs};
 /// assert_eq!(ATAN2_0_1, 0.0);
 /// ```
 pub const fn atan2(y: f64, x: f64) -> f64 {
+    nightly_exp!(atan2, atan2_inner, y, x)
+}
+
+const fn atan2_inner(y: f64, x: f64) -> f64 {
     const PI_LO: f64 = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
     if x.is_nan() || y.is_nan() {
         return x + y;

--- a/src/atanh.rs
+++ b/src/atanh.rs
@@ -6,6 +6,10 @@ use crate::log1p::log1p;
 /// Calculates the inverse hyperbolic tangent of `x`.
 /// Is defined as `log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2`.
 pub const fn atanh(x: f64) -> f64 {
+    nightly_exp!(atanh, atanh_inner, x)
+}
+
+const fn atanh_inner(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
     let sign = (u >> 63) != 0;

--- a/src/cos.rs
+++ b/src/cos.rs
@@ -51,6 +51,10 @@ use crate::{k_cos::k_cos, k_sin::k_sin, rem_pio2::rem_pio2};
 /// assert_eq!(COS_PI, -1.0);
 /// ```
 pub const fn cos(x: f64) -> f64 {
+    nightly_exp!(cos, cos_inner, x)
+}
+
+const fn cos_inner(x: f64) -> f64 {
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;
 
     /* |x| ~< pi/4 */

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -81,7 +81,11 @@ const P5: f64 = 4.13813679705723846039e-08; /* 0x3E663769, 0x72BEA4D0 */
 ///
 /// Calculate the exponential of `x`, that is, *e* raised to the power `x`
 /// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
-pub const fn exp(mut x: f64) -> f64 {
+pub const fn exp(x: f64) -> f64 {
+    nightly_exp!(exp, exp_inner, x)
+}
+
+const fn exp_inner(mut x: f64) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023
 
     let hi: f64;

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -15,6 +15,10 @@ const EXP_BIAS: u32 = EXP_SAT >> 1;
 const SIG_MASK: u64 = 4503599627370495;
 
 pub const fn floor(x: f64) -> f64 {
+    nightly_exp!(floor, floor_inner, x)
+}
+
+const fn floor_inner(x: f64) -> f64 {
     let zero = 0;
 
     let mut ix = x.to_bits();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 #![doc = include_str!("../README.md")]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::approx_constant)]
+#![allow(internal_features)]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics, const_eval_select))]
+
+#[macro_use]
+pub(crate) mod macros;
 
 mod acos;
 mod acosh;
@@ -103,6 +108,10 @@ pub const fn csc(x: f64) -> f64 {
 /// assert_eq!(SINH_0, 0.0);
 /// ```
 pub const fn sinh(x: f64) -> f64 {
+    nightly_exp!(sinh, sinh_inner, x)
+}
+
+const fn sinh_inner(x: f64) -> f64 {
     (exp(x) - exp(-x)) / 2.0
 }
 
@@ -114,6 +123,10 @@ pub const fn sinh(x: f64) -> f64 {
 /// assert_eq!(COSH_0, 1.0);
 /// ```
 pub const fn cosh(x: f64) -> f64 {
+    nightly_exp!(cosh, cosh_inner, x)
+}
+
+const fn cosh_inner(x: f64) -> f64 {
     (exp(x) + exp(-x)) / 2.0
 }
 
@@ -149,6 +162,10 @@ pub const fn factorial(mut x: f64) -> f64 {
 
 /// Const sqrt function using Newton's method
 pub const fn sqrt(x: f64) -> f64 {
+    nightly_exp!(sqrt, sqrt_inner, x)
+}
+
+const fn sqrt_inner(x: f64) -> f64 {
     if x.is_nan() || x < 0.0 {
         return f64::NAN;
     } else if x.is_infinite() || x == 0.0 {
@@ -168,11 +185,7 @@ pub const fn sqrt(x: f64) -> f64 {
 }
 
 pub const fn fabs(x: f64) -> f64 {
-    if x > 0.0 {
-        x
-    } else {
-        -x
-    }
+    x.abs()
 }
 
 const fn with_set_high_word(f: f64, hi: u32) -> f64 {

--- a/src/ln.rs
+++ b/src/ln.rs
@@ -60,7 +60,25 @@
  * to produce the hexadecimal values shown.
  */
 /// Computes natural log using a port from Rust's `libm`
-pub const fn ln(mut x: f64) -> f64 {
+pub const fn ln(x: f64) -> f64 {
+    #[cfg(feature = "nightly")]
+    {
+        #[cfg(feature = "std")]
+        {
+            std::intrinsics::const_eval_select((x,), ln_inner, f64::ln)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            core::intrinsics::const_eval_select((x,), ln_inner, libm::log)
+        }
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
+        ln_inner(x)
+    }
+}
+
+const fn ln_inner(mut x: f64) -> f64 {
     const LN2_HI: f64 = 6.93147180369123816490e-01; /* 3fe62e42 fee00000 */
     const LN2_LO: f64 = 1.90821492927058770002e-10; /* 3dea39ef 35793c76 */
     const LG1: f64 = 6.666666666666735130e-01; /* 3FE55555 55555593 */

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,21 @@
+macro_rules! nightly_exp {
+    ($pub_name:ident, $inner:ident, $($args:ident),*) => {
+        {
+            #[cfg(feature = "nightly")]
+            {
+                #[cfg(feature = "std")]
+                {
+                    std::intrinsics::const_eval_select(($($args,)*), $inner, f64::$pub_name)
+                }
+                #[cfg(not(feature = "std"))]
+                {
+                    core::intrinsics::const_eval_select(($($args,)*), $inner, libm::$pub_name)
+                }
+            }
+            #[cfg(not(feature = "nightly"))]
+            {
+                $inner($($args),*)
+            }
+        }
+    };
+}

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -96,6 +96,24 @@ const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 t
 /// assert_eq!(pow(10.0, 2.0), 100.0);
 /// ```
 pub const fn pow(x: f64, y: f64) -> f64 {
+    #[cfg(feature = "nightly")]
+    {
+        #[cfg(feature = "std")]
+        {
+            std::intrinsics::const_eval_select((x, y), pow_inner, f64::powf)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            core::intrinsics::const_eval_select((x, y), pow_inner, libm::pow)
+        }
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
+        pow_inner(x, y)
+    }
+}
+
+const fn pow_inner(x: f64, y: f64) -> f64 {
     let t1: f64;
     let t2: f64;
 

--- a/src/sin.rs
+++ b/src/sin.rs
@@ -51,6 +51,10 @@ use crate::{k_cos::k_cos, k_sin::k_sin, rem_pio2::rem_pio2};
 /// float_eq(SIN_PI, 0.0);
 /// ```
 pub const fn sin(x: f64) -> f64 {
+    nightly_exp!(sin, sin_inner, x)
+}
+
+const fn sin_inner(x: f64) -> f64 {
     /* High word of x. */
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;
 

--- a/src/tan.rs
+++ b/src/tan.rs
@@ -44,6 +44,10 @@ use super::{k_tan::k_tan, rem_pio2::rem_pio2};
 ///
 /// `x` is specified in radians.
 pub const fn tan(x: f64) -> f64 {
+    nightly_exp!(tan, tan_inner, x)
+}
+
+const fn tan_inner(x: f64) -> f64 {
     // let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120
 
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;


### PR DESCRIPTION
This adds a nightly feature. If we are running in nightly, we are now exposed to this function: https://doc.rust-lang.org/std/intrinsics/fn.const_eval_select.html, where we can determine if we are running at runtime or a const context.